### PR TITLE
Don't use deprecated functions OGR_G_Equal and OGR_G_Intersect any more.

### DIFF
--- a/ogr.c
+++ b/ogr.c
@@ -1652,7 +1652,7 @@ PHP_FUNCTION(ogr_g_intersect)
                              le_GeometryRef);
     }
     if (hOtherGeometry && hGeometry){
-        RETURN_LONG(OGR_G_Intersect(hGeometry, hOtherGeometry));
+        RETURN_LONG(OGR_G_Intersects(hGeometry, hOtherGeometry));
     }
 }
 
@@ -1683,7 +1683,7 @@ PHP_FUNCTION(ogr_g_equal)
                              le_GeometryRef);
     }
     if (hOtherGeometry && hGeometry){
-        RETURN_LONG(OGR_G_Equal(hGeometry, hOtherGeometry));
+        RETURN_LONG(OGR_G_Equals(hGeometry, hOtherGeometry));
     }
 }
 


### PR DESCRIPTION
This commit omits some deprecated warnings.