### PR TITLE
pass create options to c api

### DIFF
--- a/ogr.c
+++ b/ogr.c
@@ -903,7 +903,7 @@ static char **  php_array2string(char **papszStrList, zval *refastrvalues)
 										 (void **) &tmp) == SUCCESS) {
 		convert_to_string_ex(tmp);
 
-        papszStrList = (char **)CSLAddString(papszStrList, (char *)tmp);
+        papszStrList = (char **)CSLAddString(papszStrList, Z_STRVAL_PP(tmp));
 
 		zend_hash_move_forward(Z_ARRVAL_P(refastrvalues));
 	}


### PR DESCRIPTION
Repair broken array2string function, making create options being passed to the C api again.